### PR TITLE
[Bugfix] Undefined results shouldn't be searchable

### DIFF
--- a/quickspot.js
+++ b/quickspot.js
@@ -1130,7 +1130,7 @@
 			// if we only want to search some
 			if (search_fields) {
 				for (c in search_fields) {
-					tmp += " " + util.extractValue(item, search_fields[c]);
+					tmp += " " + (util.extractValue(item, search_fields[c])||"");
 				}
 				return tmp;
 			}

--- a/quickspot.js
+++ b/quickspot.js
@@ -1130,7 +1130,7 @@
 			// if we only want to search some
 			if (search_fields) {
 				for (c in search_fields) {
-					tmp += " " + (util.extractValue(item, search_fields[c])||"");
+					tmp += " " + util.extractValue(item, search_fields[c]);
 				}
 				return tmp;
 			}
@@ -1426,6 +1426,8 @@
 
 		if (typeof tmp === "string" || typeof tmp === "number") {
 			return tmp;
+		} else {
+			return "";
 		}
 	};
 


### PR DESCRIPTION
If an undefined value is extracted, it becomes possible to search "undefined" and receive results. This doesn't seem like expected behaviour.

I've applied this to the `searchValues` function as I can't be 100% sure that the rest of the codebase doesn't rely on undefined results from `extractValue`