### PR TITLE
Cast everything to a string before calling toLowerCase

### DIFF
--- a/quickspot.js
+++ b/quickspot.js
@@ -1276,7 +1276,11 @@
 		 * @return simplified string
 		 */
 		ds.simplfy_strings = function(str) {
-			// all lower ase
+			// cast to string if necessary
+			if (typeof str !== 'string') {
+				str = String(str);
+			}
+			// all lower case
 			str = str.toLowerCase();
 			// & -> and
 			str = str.replace(/\&/g, "and");

--- a/quickspot.js
+++ b/quickspot.js
@@ -1278,7 +1278,8 @@
 		ds.simplfy_strings = function(str) {
 			// cast to string if necessary
 			if (typeof str !== 'string') {
-				str = String(str);
+				// Don't stringify non-primitives
+				str = util.isPrimitive(str) ? String(str) : '';
 			}
 			// all lower case
 			str = str.toLowerCase();
@@ -1433,6 +1434,20 @@
 		} else {
 			return "";
 		}
+	};
+	
+	// Check whether a value is a defined primitive
+	util.isPrimitive = function(val) {
+	    if (val === null) {
+		return false;
+	    }
+	    switch(typeof val) {
+		case 'object':
+		case 'undefined':
+		case 'function':
+		    return false;
+	    }
+	    return true;
 	};
 
 	// High speed occurrences function (amount of matches within a string)


### PR DESCRIPTION
If a number gets processed, it will kill the initialisation as it doesn't have a `toLowerCase` function. This will be true for other data types. Cast to string before calling `toLowerCase`