### PR TITLE
[Enhancement] Adds maintain_order option which stops resorting the data its given

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ QuickSpot implements a number of advanced methods which can be used to further c
 * `options.allow_partial_matches` - Filter results by individual words rather than by the full phrase. This is enabled by default. (true|false)
 * `options.show_all_on_blank_search` - True|false - Rather than hiding when no search terms are entered, this will instead cause quickspot to list all valid results (results that are not filtered out). False by default.
 * `options.events` - Quick method of binding up events. Takes an object of event name, callback pairs.
+* `options.maintain_order` - `'always'`|`'initial'` - Maintain the order of the data as it was given when showing full data set (using `'initial'`) or for all results listings (using `'always'`)
 
 In addition you can also extend quickspots base functionality significantly through the use of the following callbacks.
 


### PR DESCRIPTION
Adds new option `maintain_order`, which will keep results ordered in the same sequence as the original data source. This is useful for API data which has already been sorted in a specific way for example.

The option recognises two values, `'initial'` and `'always'`. The former will only apply the order when the full data set is being displayed (for instance when `.all()` or `.search('')` are used). The latter will apply the order to any result set.

This feature is behind an option as it requires extra setup work (to grab the order) and relies on `.map`, which takes native compatibility to IE9 (though a shim as per MDN is also included).

This PR also includes an internal datastore function `ds.get_item_key` which moves the standard key getter into its own function so it's reusable during initialisation.

### Example usage

```
const dataset = [
    {id: 2, item: 'apple', colour: 'red'},
    {id: 8, item: 'banana', colour: 'yellow'},
    {id: 0, item: 'peach', colour: 'orange'},
    {id: 1, item: 'orange', colour: 'orange'},
];

const controlStore = quickspot.datastore({
    data: dataset,
    key_value: 'id'
});

const orderedStore = quickspot.datastore({
    data: dataset,
    key_value: 'id',
    maintain_order: 'always'
});

controlStore.store.all();
// controlStore.store.results === [{id: 0, ...}, {id: 1, ...}, {id: 2, ...}, {id: 8, ...}]
orderedStore.store.all();
// orderedStore.store.results === [{id: 2, ...}, {id: 8, ...}, {id: 0, ...}, {id: 1, ...}]

// The functionality below only applies to maintain_order === 'always'

controlStore.store.search('orange');
// controlStore.store.results === [{id: 1, ...}, {id: 0, ...}] as 'orange' appears twice
orderedStore.store.search('orange');
// orderedStore.store.results === [{id: 0, ...}, {id: 1, ...}] as {id: 0, ...} is first in the original data
```